### PR TITLE
workaround missing XML DTD error in Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: html examples
 pdf: LibeventBook.pdf
 
 LibeventBook.pdf: *.txt examples*/*.c
-	a2x -f pdf LibeventBook.txt
+	a2x -f pdf LibeventBook.txt --no-xmllint
 
 html: $(GENERATED_HTML)
 


### PR DESCRIPTION
In Mac OS X, attempting to build the PDF fails with a missing DTD error. We can work around this by disabling xmllint.
