### PR TITLE
add comment about EVLOOP_NO_EXIT_ON_EMPTY

### DIFF
--- a/Ref3_eventloop.txt
+++ b/Ref3_eventloop.txt
@@ -87,7 +87,7 @@ flags set.  Thus, it keeps running until there are no more registered events
 or until event_base_loopbreak() or event_base_loopexit() is called.
 
 These functions are defined in <event2/event.h>.  They have existed since
-Libevent 1.0.
+Libevent 1.0. EVLOOP_NO_EXIT_ON_EMPTY	existed since Libevent 2.1.1-alpha.
 
 Stopping the loop
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
EVLOOP_NO_EXIT_ON_EMPTY	existed since Libevent 2.1.1-alpha not Libevent 1.0, so I add a comment.

see 

https://github.com/libevent/libevent/blob/91a2f1346e80c67526261ba81c8f3b3736107bcb/ChangeLog#L1637