### PR TITLE
Deploy to github pages (libevent.org/book/)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+---
+name: pages
+
+on:
+  push:
+    branches: [$default-branch]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: Install Depends
+        run: |
+          sudo apt-get update
+          sudo apt-get install asciidoc libevent-dev
+      - name: Build
+        shell: bash
+        run: |
+          make
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Adds CI to deploy repository to https://libevent.org/book/

Refs: https://github.com/libevent/libevent/issues/1370